### PR TITLE
SUR-000: upgrade tf requirement to 0.13

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ locals {
 }
 
 module "origin_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.25.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -144,7 +144,7 @@ resource "aws_s3_bucket" "origin" {
 }
 
 module "logs" {
-  source                   = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.9.0"
+  source                   = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.25.0"
   enabled                  = var.logging_enabled
   namespace                = var.namespace
   stage                    = var.stage
@@ -160,7 +160,7 @@ module "logs" {
 }
 
 module "distribution_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.25.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -331,7 +331,7 @@ resource "aws_cloudfront_distribution" "default" {
 }
 
 module "dns" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.4.0"
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.13.0"
   enabled          = var.enabled && (var.parent_zone_id != "" || var.parent_zone_name != "") ? true : false
   aliases          = var.aliases
   parent_zone_id   = var.parent_zone_id

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,22 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws      = "~> 2.0"
-    template = "~> 2.0"
-    local    = "~> 1.2"
-    null     = "~> 2.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.2"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 2.0"
+    }
   }
 }


### PR DESCRIPTION
## what
* upgrade tf version requirement to 0.13
* upgrade modules to versions that support tf version 0.13

## why
* trying to get closer to supporting tf 1.0.8 for our cdns

## notes for reviewers
* I'll probably have to do a few releases, upgrading modules as needed each major tf upgrade
* I'm not really sure how to test this. I did a local terraform 0.13upgrade and terraform init with tf version 0.13.0 to make sure that was all good and picked versions of the modules that support 0.13. Figured I'd do a release, update the thank you page module to use that version, and fix any issues from there.
* I don't love that we're having to keep a fork up to date, but we forked because it doesn't look like they support log bucket tags. For now maybe it makes sense to upgrade the fork so we can upgrade tf on our end, then we can look into bringing our fork up to date or maybe contributing to their repo so they support tags.

